### PR TITLE
fix: set color with custom theme

### DIFF
--- a/app/docs/customize/theme/theme.mdx
+++ b/app/docs/customize/theme/theme.mdx
@@ -65,6 +65,6 @@ const customTheme: CustomFlowbiteTheme['button'] = {
 };
 
 export default function MyPage() {
-  return <Button theme={customTheme}>Click me</Button>;
+  return <Button theme={customTheme} color="primary">Click me</Button>;
 }
 ```


### PR DESCRIPTION
- [ X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
Attributes like color must be set when using a custom theme on a component.
Documentation wasn't working out of the box.

Reference related issues using `#` followed by the issue number.
No issue created

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

No API change
